### PR TITLE
fix(server): correctly determine preselection

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -31,9 +31,9 @@ function getQueryName() {
 
   const
     allNames = Object.keys( cachedLiveDates ).filter( ( name ) => name !== '@lastQueried' ),
-    randomName = allNames.length > 0 ? allNames[ Math.round( Math.random() * allNames.length ) ] : '';
+    randomName = allNames.length > 0 ? allNames[ Math.round( Math.random() * ( allNames.length - 1 ) ) ] : '';
 
-  return randomName || randomStartupNames[ Math.round( Math.random() * randomStartupNames.length ) ]; // eslint-disable-line id-match
+  return randomName || randomStartupNames[ Math.round( Math.random() * ( randomStartupNames.length - 1 ) ) ]; // eslint-disable-line id-match
 }
 
 function proxyGetLiveDates( name ) {


### PR DESCRIPTION
When setting a random previously fetched or predetermined name, the resulting index in the list was erroneously determined by the corresponding `array.length` instead of `array.length - 1`.
